### PR TITLE
fix: navigate to exact line when clicking #L anchor links in markdown preview

### DIFF
--- a/src/mdEditorProvider.ts
+++ b/src/mdEditorProvider.ts
@@ -400,24 +400,32 @@ export class MDEditorProvider implements vscode.CustomReadonlyEditorProvider {
                         try {
                             const href = typeof message.href === 'string' ? message.href : '';
                             const docUri = typeof message.documentUri === 'string' ? message.documentUri : '';
-                            
+
                             if (!href || !docUri) {
                                 break;
                             }
-                            
-                            // Parse the document URI to get the file path
+
                             const currentDocUri = vscode.Uri.parse(docUri);
                             const currentDir = path.dirname(currentDocUri.fsPath);
-                            
-                            // Remove any anchor/hash from the href
-                            const hrefWithoutAnchor = href.split('#')[0];
-                            
-                            // Resolve the relative path
+
+                            const hashIndex = href.indexOf('#');
+                            const hrefWithoutAnchor = hashIndex !== -1 ? href.slice(0, hashIndex) : href;
+                            const anchor = hashIndex !== -1 ? href.slice(hashIndex + 1) : '';
+
                             const resolvedPath = path.resolve(currentDir, hrefWithoutAnchor);
                             const targetUri = vscode.Uri.file(resolvedPath);
-                            
-                            // Open the file
-                            await vscode.commands.executeCommand('vscode.open', targetUri);
+
+                            // Parse #L1669 style line anchors
+                            const lineMatch = anchor.match(/^L(\d+)/);
+                            if (lineMatch) {
+                                const lineNum = parseInt(lineMatch[1], 10) - 1;
+                                const doc = await vscode.workspace.openTextDocument(targetUri);
+                                await vscode.window.showTextDocument(doc, {
+                                    selection: new vscode.Range(lineNum, 0, lineNum, 0)
+                                });
+                            } else {
+                                await vscode.commands.executeCommand('vscode.open', targetUri);
+                            }
                         } catch (err) {
                             vscode.window.showErrorMessage(`Failed to open file: ${err}`);
                         }


### PR DESCRIPTION
…card_main.c#L1669) | not just the page. it was## Problem
Clicking relative file links with line anchors (e.g. `[see code](idcard_main/idcard_main.c#L1669)`) 
in the markdown preview opened the file but ignored the line number — always landing at line 0.

## Root Cause
In `mdEditorProvider.ts`, the `openRelativeFile` handler stripped everything after `#` before 
opening the file, discarding the `#L1669` line anchor.

## Fix
- Parse the anchor separately before stripping it from the file path
- Detect `#L{number}` pattern
- Use `vscode.window.showTextDocument` with a `Range` to jump to the exact line

## Testing
Open a `.md` file containing a relative link with `#L` anchor → click it → file opens at correct line.
 slicing that section before